### PR TITLE
Fixing calls to log/add in Rail.logger

### DIFF
--- a/docs/parsing_email.md
+++ b/docs/parsing_email.md
@@ -18,8 +18,8 @@ Rails 3 already makes use of mail instead of using TMail that was default in Rai
   
       def create
         message = Mail.new(params[:message])
-        Rails.logger.log message.subject #print the subject to the logs
-        Rails.logger.log message.body.decoded #print the decoded body to the logs
+        Rails.logger.log Logger::INFO, message.subject #print the subject to the logs
+        Rails.logger.log Logger::INFO, message.body.decoded #print the decoded body to the logs
     
         # Do some other stuff with the mail message
     
@@ -49,8 +49,8 @@ Then create a controller `script/generate controller incoming_mails`. You are fr
       
       def create
         message = Mail.new(params[:message])
-        Rails.logger.log message.subject #print the subject to the logs
-        Rails.logger.log message.body.decoded #print the decoded body to the logs
+        Rails.logger.add Logger::INFO, message.subject #print the subject to the logs
+        Rails.logger.add Logger::INFO, message.body.decoded #print the decoded body to the logs
         
         # Do some other stuff with the mail message
         


### PR DESCRIPTION
The Logger class in Rails 3 supports add/log, but the method requires that you
pass in the severity. There are also methods that infer the severity in
the name (i.e. WARN(message), INFO(message) ).

The BufferedLogger class (used pre Rails 3) does not the log method (an
alias to add) nor the named log-level convenience methods. So, you have
to use 'add' and pass the severity.
