### PR TITLE
Cleaning up Python docs

### DIFF
--- a/content/receiving_email/examples/python.md
+++ b/content/receiving_email/examples/python.md
@@ -9,7 +9,5 @@ skip_erb: true
 
 [Jeremy Carbaugh](https://github.com/jcarbaugh) at Sunlight Foundation constructed a Django client for CloudMailin's original format so that you can use CloudMailin to receive email easily from within your Django Apps.
 
-The code and usage examples are up on [Github](https://github.com/CloudMailin/django-cloudmailin) so we suggest you take a look and try it out for yourself!
+The code and usage examples are up on [Github](https://github.com/CloudMailin/django-cloudmailin). We suggest you take a look and try it out for yourself!
 
-For this reason we decided to make our documentation system available on [Github](http://github.com/cloudmailin/docs.cloudmailin.com).
-Please help us and the other people using your language out and contribute some examples and send us a pull request!


### PR DESCRIPTION
Last paragraph did not relate to the rest of the page. Even if it had, it was poorly written.

I will make a second pull request once you pull this one. The second request will have more Python examples using CloudMailin with Python.
