### PR TITLE
Badge external website results in docs search

### DIFF
--- a/content/assets/javascripts/search.js
+++ b/content/assets/javascripts/search.js
@@ -38,7 +38,8 @@ autocomplete({
           },
           item({ item, components, html }) {
             return html`<a href="${item.objectID}" class="search-result">
-              <h4>${item.title}</h4>
+              <h4>${item.title}${item.external
+                ? html`<span class="search-badge">cloudmailin.com</span>` : ''}</h4>
               <p>${components.Highlight({ hit: item, attribute: 'description' })}</p>
             </a>`;
           }

--- a/content/assets/stylesheets/docs_new.scss
+++ b/content/assets/stylesheets/docs_new.scss
@@ -150,6 +150,23 @@ a.search-result, a.search-result:hover {
     color: var(--search-result-prevew-color);
     margin-bottom: 0px;
   }
+
+  .search-badge {
+    display: inline-block;
+    margin-left: 6px;
+    padding: 0px 6px;
+    border: 1px solid currentColor;
+    border-radius: 8px;
+    font-size: x-small;
+    font-weight: normal;
+    vertical-align: middle;
+    color: var(--search-result-prevew-color);
+
+    &::after {
+      // north-east arrow, forced text presentation (no emoji rendering)
+      content: ' \2197\FE0E';
+    }
+  }
 }
 
 #middle {


### PR DESCRIPTION
Search results indexed from www.cloudmailin.com (via the external indexer from #73) now show a small `cloudmailin.com` pill next to the title, making it clear those results navigate away from the docs. Docs results are unchanged. Verified locally against the production index (read-only, public search key).